### PR TITLE
 Рекомендательная система для фильмов.

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -193,13 +193,13 @@ public class FilmService {
         // Фильмы которые лайкнул целевой пользователь
         Set<Integer> likeByUser = filmDbStorage.getLikedFilms(userId);
         if (likeByUser.isEmpty()) {
-            return getPopularFilms(limit);
+            return List.of();
         }
 
         // Пользователи, лайкнувшие любой из фильмов(кроме самого userId)
         Set<Integer> neighborsUsers = filmDbStorage.getUsersPairsForAnyFilms(likeByUser, userId);
         if (neighborsUsers.isEmpty()) {
-            return getPopularFilms(limit);
+            return List.of();
         }
 
         // Подсчёт общих лайков у каждого соседа с целевым
@@ -213,7 +213,7 @@ public class FilmService {
             scopeByFilm.merge(filmId, 1, Integer::sum);
         }
         if (scopeByFilm.isEmpty()) {
-            return getPopularFilms(limit);
+            return List.of();
         }
 
         // Вывод топ N-рекомендаций

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -13,7 +13,10 @@ import ru.yandex.practicum.filmorate.storage.film.FilmStorage;
 import ru.yandex.practicum.filmorate.storage.film.GenreDbStorage;
 import ru.yandex.practicum.filmorate.storage.film.MpaDbStorage;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 public class FilmService {
@@ -176,5 +179,50 @@ public class FilmService {
         log.debug("Получение жанра с id {}", id);
         return genreStorage.getGenreById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Жанр с id " + id + " не найден"));
+    }
+
+    // Бизнес-логика для рекомендаций
+    public List<Film> getRecomendation(int userId, int limit) {
+        // Проверка на существование пользователей
+        userService.getUserById(userId);
+
+        if (!(filmStorage instanceof FilmDbStorage filmDbStorage)) {
+            return List.of();
+        }
+
+        // Фильмы которые лайкнул целевой пользователь
+        Set<Integer> likeByUser = filmDbStorage.getLikedFilms(userId);
+        if (likeByUser.isEmpty()) {
+            return getPopularFilms(limit);
+        }
+
+        // Пользователи, лайкнувшие любой из фильмов(кроме самого userId)
+        Set<Integer> neighborsUsers = filmDbStorage.getUsersPairsForAnyFilms(likeByUser, userId);
+        if (neighborsUsers.isEmpty()) {
+            return getPopularFilms(limit);
+        }
+
+        // Подсчёт общих лайков у каждого соседа с целевым
+        List<Integer> allFilmsBySimilar = filmDbStorage.getFilmIdsLikedByUsers(neighborsUsers);
+
+        Map<Integer, Integer> scopeByFilm = new HashMap<>();
+        for (Integer filmId : allFilmsBySimilar) {
+            if (likeByUser.contains(filmId)) {
+                continue;
+            }
+            scopeByFilm.merge(filmId, 1, Integer::sum);
+        }
+        if (scopeByFilm.isEmpty()) {
+            return getPopularFilms(limit);
+        }
+
+        // Вывод топ N-рекомендаций
+        List<Integer> topFilmIds = scopeByFilm.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(Math.max(1, limit))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        return filmDbStorage.getFilmsByIdRestoringOrder(topFilmIds);
     }
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorageTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorageTest.java
@@ -12,6 +12,8 @@ import ru.yandex.practicum.filmorate.model.Genre;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Arrays;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -131,4 +133,33 @@ class FilmDbStorageTest {
         assertThat(genres).extracting(Genre::getName)
                 .contains("Комедия", "Драма", "Боевик");
     }
+
+    @Test
+    public void getFilmsByIdsPreserveOrder_returnsInSameOrder() {
+        // создаём 3 фильма
+        Film f1 = filmStorage.create(makeFilm("Order-1"));
+        Film f2 = filmStorage.create(makeFilm("Order-2"));
+        Film f3 = filmStorage.create(makeFilm("Order-3"));
+
+        // Запрос в "перемешанном" порядке: f2, f1
+        List<Film> ordered = filmStorage.getFilmsByIdRestoringOrder(Arrays.asList(f2.getId(), f1.getId()));
+
+        assertThat(ordered).hasSize(2);
+        assertThat(ordered.get(0).getId()).isEqualTo(f2.getId());
+        assertThat(ordered.get(1).getId()).isEqualTo(f1.getId());
+    }
+
+    /* Утилита для локального создания фильма с MPA (как в setUp) */
+    private Film makeFilm(String name) {
+        Film f = new Film();
+        f.setName(name);
+        f.setDescription(name + " desc");
+        f.setReleaseDate(LocalDate.of(2000, 1, 1));
+        f.setDuration(100);
+        MpaRating m = new MpaRating();
+        m.setId(1);
+        f.setMpa(m);
+        return f;
+    }
+
 }


### PR DESCRIPTION
Что добавлено: 
Эндпоинт GET /users/{id}/recommendations?count={N} в UserController — валидирует пользователя и возвращает список фильмов-рекомендаций, дефолтный count=10.

Бизнес-логика рекомендаций в FilmService#getRecomendation(int userId, int limit) — алгоритм user-based CF по лайкам:

1. берём фильмы, которые лайкнул целевой пользователь;

2. находим пользователей, лайкнувших любой из этих фильмов (исключая целевого);

3. собираем их лайки, исключаем уже лайкнутые целевым;

4. считаем «скор» фильма как количество лайков от «похожих» пользователей;

5. сортируем по убыванию score и ограничиваем limit;

6. fallback: если нет лайков/похожих/кандидатов — отдаём популярные фильмы.

Что вынесено в хранилище:

Добавлены простые методы-выборки без бизнес-логики:

Set<Integer> getLikedFilms(int userId) — все id фильмов, лайкнутых пользователем.

Set<Integer> getUsersPairsForAnyFilms(Set<Integer> filmsId, int excludeUserId) — пользователи, лайкнувшие любой из заданных фильмов, кроме excludeUserId.

List<Integer> getFilmIdsLikedByUsers(Set<Integer> usersId) — все id фильмов, лайкнутых данными пользователями.

List<Film> getFilmsByIdRestoringOrder(List<Integer> filmsId) — загрузка фильмов по списку id с сохранением исходного порядка (плюс подгрузка жанров).

Тесты:

UserControllerTest

Добавлены кейсы:

getRecommendationsReturnsFromSimilarUsers — рекомендации приходят от «похожих» пользователей; уже лайкнутые фильмы целевому не возвращаются.

getRecommendationsRespectsLimitAndOrder — учитывается limit, порядок по убыванию score (B выше C при двух «похожих» лайках).

Для тестов добавлены поля FilmService и FilmDbStorage, утилита film(String) для быстрого создания фильмов.

FilmDbStorageTest

getFilmsByIdsPreserveOrder_returnsInSameOrder — метод getFilmsByIdRestoringOrder возвращает фильмы в том же порядке, что и список id на входе (f2, f1).