### PR TITLE
Вывод общих с другом фильмов с сортировкой по их популярности.

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -8,9 +8,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @RestController
@@ -48,6 +50,13 @@ public class FilmController extends BaseController<Film> {
             log.error("Фильм с id {} не найден", id);
             return createErrorResponse(e.getMessage(), HttpStatus.NOT_FOUND);
         }
+    }
+
+    @GetMapping("/common")
+    public List<Film> getFilmByPopularityCommon(@RequestParam(name = "userId") int userId,
+                                                @RequestParam(name = "friendId") int friendId) {
+        log.info("Получен запрос на вывод популярных общих фильмов, {} и {}", userId, friendId);
+        return filmService.getFilmByPopularityCommon(userId, friendId);
     }
 
     @PutMapping("/{id}/like/{userId}")

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Slf4j
 @RestController

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -142,6 +142,7 @@ public class FilmDbStorage implements FilmStorage {
         jdbcTemplate.update(sql, filmId, userId);
     }
 
+    @Override
     public List<Integer> getLikes(int filmId) {
         String sql = "SELECT user_id FROM likes WHERE film_id = ?";
         return jdbcTemplate.queryForList(sql, Integer.class, filmId);
@@ -186,6 +187,27 @@ public class FilmDbStorage implements FilmStorage {
 
         return film;
     }
+
+    // Реализация запроса на вывод общих фильмов друзей
+    public Set<Integer> getCommonFilms(int userId, int friendId) {
+        String sql = """
+                SELECT DISTINCT l1.film_id
+                FROM likes l1
+                JOIN likes l2 ON l1.film_id = l2.film_id
+                WHERE l1.user_id = ? AND l2.user_id = ?
+                """;
+        return new HashSet<>(jdbcTemplate.queryForList(sql, Integer.class, userId, friendId));
+    }
+
+    @Override
+    public Integer getLikeCount(int filmId) {
+        String sql = """
+                SELECT COUNT(*) FROM likes WHERE film_id = ?;
+                """;
+        return jdbcTemplate.queryForObject(sql, Integer.class, filmId);
+    }
+
+    // Остальная часть реализации приложения
 
     private MpaRating mapMpaRating(ResultSet rs, int rowNum) throws SQLException {
         MpaRating mpa = new MpaRating();

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -1,6 +1,7 @@
 package ru.yandex.practicum.filmorate.storage.film;
 
 import ru.yandex.practicum.filmorate.model.Film;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,8 @@ public interface FilmStorage {
     void delete(int id);
 
     boolean exists(int id);
+
+    public List<Integer> getLikes(int filmId);
+
+    public Integer getLikeCount(int filmId);
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorageTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorageTest.java
@@ -8,6 +8,11 @@ import org.springframework.context.annotation.Import;
 import ru.yandex.practicum.filmorate.model.Film;
 import ru.yandex.practicum.filmorate.model.MpaRating;
 import ru.yandex.practicum.filmorate.model.Genre;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.storage.user.UserDbStorage;
+
+import java.util.Set;
+
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,11 +21,19 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
-@Import({FilmDbStorage.class})
+@Import({FilmDbStorage.class, UserDbStorage.class, MpaDbStorage.class, GenreDbStorage.class})
 class FilmDbStorageTest {
 
     @Autowired
     private FilmDbStorage filmStorage;
+
+    @Autowired
+    private UserDbStorage userStorage;
+
+    private int userA;
+    private int userB;
+    private int userC;
+
 
     private Film testFilm;
 
@@ -35,6 +48,11 @@ class FilmDbStorageTest {
         MpaRating mpa = new MpaRating();
         mpa.setId(1);
         testFilm.setMpa(mpa);
+
+        userA = createUser("a@mail.com", "a");
+        userB = createUser("b@mail.com", "b");
+        userC = createUser("c@mail.com", "c");
+
     }
 
     @Test
@@ -131,4 +149,71 @@ class FilmDbStorageTest {
         assertThat(genres).extracting(Genre::getName)
                 .contains("Комедия", "Драма", "Боевик");
     }
+
+    @Test
+    void getCommonFilms_returnsIntersectionOnly() {
+        int f1 = filmStorage.create(film("F1")).getId();
+        int f2 = filmStorage.create(film("F2")).getId();
+        int f3 = filmStorage.create(film("F3")).getId();
+
+        filmStorage.addLike(f1, userA);
+        filmStorage.addLike(f1, userB);
+
+        filmStorage.addLike(f2, userA);
+        filmStorage.addLike(f2, userB);
+        filmStorage.addLike(f2, userC);
+
+        Set<Integer> ids = filmStorage.getCommonFilms(userA, userB);
+        assertThat(ids).containsExactlyInAnyOrder(f1, f2);
+        assertThat(ids).doesNotContain(f3);
+    }
+
+    @Test
+    void getLikeCount_countsAccurately() {
+        int f1 = filmStorage.create(film("F1")).getId();
+        int f2 = filmStorage.create(film("F2")).getId();
+        int f3 = filmStorage.create(film("F3")).getId();
+
+        filmStorage.addLike(f1, userA);
+        filmStorage.addLike(f1, userB);
+
+        filmStorage.addLike(f2, userA);
+        filmStorage.addLike(f2, userB);
+        filmStorage.addLike(f2, userC);
+
+        assertThat(filmStorage.getLikeCount(f1)).isEqualTo(2);
+        assertThat(filmStorage.getLikeCount(f2)).isEqualTo(3);
+        assertThat(filmStorage.getLikeCount(f3)).isEqualTo(0);
+    }
+
+    @Test
+    void getCommonFilms_isDistinct_noDuplicates() {
+        int f1 = filmStorage.create(film("F1")).getId();
+        filmStorage.addLike(f1, userA);
+        filmStorage.addLike(f1, userB);
+        filmStorage.removeLike(f1, userA);
+        filmStorage.addLike(f1, userA);
+
+        Set<Integer> ids = filmStorage.getCommonFilms(userA, userB);
+        assertThat(ids).containsExactlyInAnyOrder(f1);
+    }
+
+    private Film film(String name) {
+        Film f = new Film();
+        f.setName(name);
+        f.setDescription(name + " desc");
+        f.setReleaseDate(LocalDate.of(2000, 1, 1));
+        f.setDuration(100);
+        return f;
+    }
+
+    private int createUser(String email, String login) {
+        User u = new User();
+        u.setEmail(email);
+        u.setLogin(login);
+        u.setName(login.toUpperCase());
+        u.setBirthday(LocalDate.of(1990, 1, 1));
+        return userStorage.create(u).getId();
+    }
+
 }


### PR DESCRIPTION
Что добавлено:
Эндпоинт GET /films/common?userId={userId}&friendId={friendId} в FilmController: — валидирует вход и возвращает список общих фильмов двух пользователей, отсортированных по популярности.

Бизнес-логика общих фильмов getFilmByPopularityCommon(int userId, int friendId):

1. валидирует наличие обоих пользователей;
2. проверяем, что friendId содержится в userService.getFriends(userId) — иначе возвращаем пустой список;
3. через DAO получаем множество общих фильмов по пересечению лайков;
4. загружаем объекты фильмов;
5. считаем «популярность» (внутренний счётчик на фильм) и сортируем по убыванию;
6. возвращаем отсортированный список общих фильмов.

FilmDbStorage:

Добавлены методы-выборки:

getCommonFilms(int userId, int friendId) — пересечение лайков двух пользователей:

getLikeCount(int filmId) — количество лайков у фильма:

Тесты

FilmControllerTest:

getCommonFilms_sortedByPopularity_desc — общее множество фильмов для двух пользователей и порядок по «популярности». getCommonFilms_noIntersection_returnsEmpty — пустой результат при отсутствии пересечения лайков. getCommonFilms_unknownUser_throws — валидация при неизвестном пользователе. вспомогательная инициализация пользователей в @BeforeEach, «двусторонняя» заявка в друзья addFriend(userA, userB) и addFriend(userB, userA);

FilmDbStorageTest:
getLikeCount_countsAccurately — проверяет корректный подсчёт лайков по фильмам.